### PR TITLE
Update Dockerfile with Ubuntu Trusty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:trusty
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV PATH $PATH:/usr/local/nginx/sbin


### PR DESCRIPTION
Ubuntu's latest tag is no longer Trusty, need to specify trusty as a tag to build properly.
